### PR TITLE
Add emit_bc feature

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -55,6 +55,7 @@ load(
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
+    "SWIFT_FEATURE_EMIT_BC",
 )
 load(":features.bzl", "are_all_features_enabled", "is_feature_enabled")
 load(":providers.bzl", "SwiftInfo", "create_swift_info")
@@ -92,9 +93,19 @@ def compile_action_configs():
     action_configs = [
         # Emit object file(s).
         swift_toolchain_config.action_config(
-            actions = [swift_action_names.COMPILE],
+            actions=[swift_action_names.COMPILE],
+            not_features = [SWIFT_FEATURE_EMIT_BC],
             configurators = [
                 swift_toolchain_config.add_arg("-emit-object"),
+            ],
+        ),
+
+        # Emit bitcode file
+        swift_toolchain_config.action_config(
+            actions=[swift_action_names.COMPILE],
+            features = [SWIFT_FEATURE_EMIT_BC],
+            configurators = [
+                swift_toolchain_config.add_arg("-emit-bc"),
             ],
         ),
 
@@ -1567,10 +1578,15 @@ def _declare_compile_outputs(
         user_compile_flags = user_compile_flags,
     )
 
-    if not output_nature.emits_multiple_objects:
+    emit_bc = is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_EMIT_BC,
+    )
+    if not output_nature.emits_multiple_objects or emit_bc:
         # If we're emitting a single object, we don't use an object map; we just
         # declare the output file that the compiler will generate and there are
         # no other partial outputs.
+        # If emit_bc is on, only one bitcode file is emitted
         object_files = [derived_files.whole_module_object_file(
             actions = actions,
             target_name = target_name,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -93,7 +93,7 @@ def compile_action_configs():
     action_configs = [
         # Emit object file(s).
         swift_toolchain_config.action_config(
-            actions=[swift_action_names.COMPILE],
+            actions = [swift_action_names.COMPILE],
             not_features = [SWIFT_FEATURE_EMIT_BC],
             configurators = [
                 swift_toolchain_config.add_arg("-emit-object"),
@@ -102,7 +102,7 @@ def compile_action_configs():
 
         # Emit bitcode file
         swift_toolchain_config.action_config(
-            actions=[swift_action_names.COMPILE],
+            actions = [swift_action_names.COMPILE],
             features = [SWIFT_FEATURE_EMIT_BC],
             configurators = [
                 swift_toolchain_config.add_arg("-emit-bc"),

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -188,3 +188,7 @@ SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
 # `*.swiftmodule` and `*-Swift.h` are generated with a separate action
 # rather than as part of the compilation.
 SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION = "swift.split_derived_files_generation"
+
+# If enabled, Swift compilation will produce LLVM bitcode instead of object file
+# the output will share the same name as the object file (file.o)
+SWIFT_FEATURE_EMIT_BC = "swift.emit_bc"


### PR DESCRIPTION
Adding emit_bc feature for bc_merge pipeline

Despite different output, `emit-object` and `emit-bc` is largely the same in terms of input flag, etc, it's still in "compiling stage", feels like a feature flag is more fitting here rather than a new action